### PR TITLE
Handling of sensitive information

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,5 @@ This project aims to define tooling allowing WildFly users to benefenit from the
 * [Container Image](container-image/README.md): A container image that contains both the chat bot and the mcp server. Ready to interact with your WildFly servers on the cloud. Example of OpenShift deployment is provided.
 
 * [MCP STDIO to SEE protocol gateway](mcp-stdio-sse-gateway/README.md): A Java gateway allowing to integrate SSE MCP servers in chat applications that only support STDIO protocol.
+
+* [Wait MCP Server](wait-mcp-server/README.md): A simple [MCP server](https://github.com/modelcontextprotocol/servers) that allows LLM to wait for some seconds. Can be useful in some workflow.

--- a/wildfly-chat-bot/mcp.json
+++ b/wildfly-chat-bot/mcp.json
@@ -4,8 +4,8 @@
             "command": "java",
             "args": [
                      "-jar",
-                     "-Dorg.wildfly.user.name=admin",
-                     "-Dorg.wildfly.user.password=admin",
+                     "-Dorg.wildfly.user.name=chatbot-user",
+                     "-Dorg.wildfly.user.password=chatbot-user",
                      "../wildfly-mcp-server/target/wildfly-mcp-server-runner.jar"]
     },
     "wait": {


### PR DESCRIPTION
* The server XML configuration is no more returned.
* A filtered (thanks to RBAC + default rules) JSON representation of the server configuration is returned.
* Make it clear in documentation what works and doesn't with a constrained access.
* Document WildFly CLI commands on how to enable RBAC.
