### PR TITLE
Add a read-only mode to the MCP server (#62)

### DIFF
--- a/wildfly-mcp-server/README.md
+++ b/wildfly-mcp-server/README.md
@@ -93,6 +93,41 @@ When a user with the `Monitor` role is used, the following tools would fail:
 
 In addition, write operations are not allowed when invoking the `invokeWildFlyCLIOperation` tool.
 
+### Read-only mode
+
+In addition to (and independently of) WildFly RBAC, the MCP server itself can be started in a read-only mode. 
+When enabled, the server refuses any operation that would modify the connected WildFly server, regardless of the 
+WildFly user's role. This provides defense-in-depth: safety no longer depends on configuring RBAC on every target server, 
+and it prevents an LLM from accidentally modifying or stopping a server.
+
+Read-only mode is enabled with the `WILDFLY_MCP_SERVER_READONLY` environment variable or the `org.wildfly.readonly` 
+system property:
+
+```
+{
+  "mcpServers": {
+    "wildfly": {
+            "command": "java",
+            "args": ["-Dorg.wildfly.readonly=true",
+                     "-Dorg.wildfly.user.name=chatbot-user",
+                     "-Dorg.wildfly.user.password=chatbot-user",
+                     "-jar",
+                     "[path to the repository]/wildfly-mcp-server/stdio/target/wildfly-mcp-server-stdio-runner.jar"]
+    }
+  }
+}
+```
+
+When read-only mode is enabled:
+
+* The following tools are not allowed and fail with an explicit message: `deployWildFlyApplication`, `undeployWildFlyApplication`, 
+`shutdownServer`, `enableWildFlyLoggingCategory`, `removeWildFlyLoggingCategory`.
+
+* The `invokeWildFlyCLIOperation` tool only allows read operations (operation names starting with `read-`, plus `query`, 
+`whoami`, `validate-address`, `validate-operation` and `list-snapshots`). Any other operation, including `composite`, is rejected.
+
+* All other read-only tools remain fully available.
+
 ## Note on sensitive information
 
 * Any sensitive information located in your server configuration file are not exposed when 

--- a/wildfly-mcp-server/README.md
+++ b/wildfly-mcp-server/README.md
@@ -123,8 +123,10 @@ When read-only mode is enabled:
 * The following tools are not allowed and fail with an explicit message: `deployWildFlyApplication`, `undeployWildFlyApplication`, 
 `shutdownServer`, `enableWildFlyLoggingCategory`, `removeWildFlyLoggingCategory`.
 
-* The `invokeWildFlyCLIOperation` tool only allows read operations (operation names starting with `read-`, plus `query`, 
-`whoami`, `validate-address`, `validate-operation` and `list-snapshots`). Any other operation, including `composite`, is rejected.
+* The `invokeWildFlyCLIOperation` tool only allows operations that the WildFly management model itself declares as read-only. 
+Before running an operation, the server is queried with `read-operation-description` and the operation is rejected unless its 
+`read-only` flag is `true`. This uses the server's own metadata as the source of truth rather than matching on the operation name, 
+so an operation that looks read-only but is implemented as a write operation is still rejected (composite operations are rejected too).
 
 * All other read-only tools remain fully available.
 

--- a/wildfly-mcp-server/common/src/main/java/org/wildfly/mcp/WildFlyMCPServer.java
+++ b/wildfly-mcp-server/common/src/main/java/org/wildfly/mcp/WildFlyMCPServer.java
@@ -92,6 +92,55 @@ public class WildFlyMCPServer {
     @RestClient
     WildFlyHealthClient wildflyHealthClient;
 
+    // Read-only mode. When enabled, the MCP server refuses any operation that
+    // would modify the connected WildFly server, independently of the WildFly
+    // user's RBAC role. Configured (like the other settings) with the
+    // WILDFLY_MCP_SERVER_READONLY env variable or the org.wildfly.readonly
+    // system property.
+    static final String READ_ONLY_ENV = "WILDFLY_MCP_SERVER_READONLY";
+    static final String READ_ONLY_PROPERTY = "org.wildfly.readonly";
+
+    // Operations allowed by invokeWildFlyCLIOperation when read-only mode is
+    // enabled. Any operation whose name starts with "read-" is allowed in
+    // addition to this set.
+    private static final Set<String> READ_ONLY_ALLOWED_OPERATIONS = Set.of(
+            "query",
+            "whoami",
+            "validate-address",
+            "validate-operation",
+            "list-snapshots");
+
+    static boolean isReadOnly() {
+        String value = System.getenv(READ_ONLY_ENV);
+        if (value == null) {
+            value = System.getProperty(READ_ONLY_PROPERTY);
+        }
+        return Boolean.parseBoolean(value);
+    }
+
+    // Returns true if the provided CLI operation is a read-only operation that
+    // is safe to run when read-only mode is enabled. Composite operations are
+    // rejected because their nested steps cannot be validated here.
+    static boolean isReadOnlyOperation(String operation) {
+        if (operation == null) {
+            return false;
+        }
+        String op = operation.trim();
+        int paren = op.indexOf('(');
+        String head = (paren >= 0 ? op.substring(0, paren) : op).trim();
+        int colon = head.lastIndexOf(':');
+        String operationName = (colon >= 0 ? head.substring(colon + 1) : head).trim().toLowerCase();
+        if (operationName.isEmpty()) {
+            return false;
+        }
+        return operationName.startsWith("read-") || READ_ONLY_ALLOWED_OPERATIONS.contains(operationName);
+    }
+
+    private ToolResponse readOnlyError(String action) {
+        return buildErrorResponse("Read-only mode is enabled (" + READ_ONLY_PROPERTY
+                + "=true): " + action + " is not allowed.");
+    }
+
     @Tool()
     @RolesAllowed("admin")
     ToolResponse getWildFlyServerConfiguration(
@@ -208,11 +257,13 @@ public class WildFlyMCPServer {
             @ToolArg(name = "port", required = false) String port,
             String operation) {
         Server server = new Server(host, port);
+        if (isReadOnly() && !isReadOnlyOperation(operation)) {
+            return readOnlyError("invoking the non read-only operation '" + operation + "'");
+        }
         try {
             User user = new User();
             CommandContext ctx = CommandContextFactory.getInstance().newCommandContext();
             ModelNode mn = ctx.buildRequest(operation);
-            // TODO, implement possible rules if needed to disallow some operations.
             String value = wildflyClient.call(server, user, mn).toJSONString(false);
             return buildResponse(value);
         } catch (Exception ex) {
@@ -229,6 +280,9 @@ public class WildFlyMCPServer {
             @ToolArg(name = "name", description = "Defaults to the last portion of the deploymentPath.", required = false) String name,
             @ToolArg(name = "runtime-name", description = "Defaults to the last portion of the deploymentPath.", required = false) String runtimeName) {
         Server server = new Server(host, port);
+        if (isReadOnly()) {
+            return readOnlyError("deploying applications");
+        }
         try {
             User user = new User();
             Path path = Paths.get(deploymentPath);
@@ -268,6 +322,9 @@ public class WildFlyMCPServer {
             @ToolArg(name = "port", required = false) String port,
             @ToolArg(name = "name", description = "Defaults to the last portion of the deploymentPath.", required = true) String name) {
         Server server = new Server(host, port);
+        if (isReadOnly()) {
+            return readOnlyError("undeploying applications");
+        }
         try {
             User user = new User();
             ModelNode response = wildflyClient.call(new UndeployRequest(server, user, name));
@@ -339,6 +396,9 @@ public class WildFlyMCPServer {
             @ToolArg(name = "port", required = false) String port,
             @ToolArg(name = "timeout", required = false, description = "Graceful shutdown timeout") Integer timeout) {
         Server server = new Server(host, port);
+        if (isReadOnly()) {
+            return readOnlyError("shutting down the server");
+        }
         try {
             User user = new User();
             ModelNode response = wildflyClient.call(new ShutdownRequest(server, user, timeout));
@@ -419,6 +479,9 @@ public class WildFlyMCPServer {
             @ToolArg(name = "port", required = false) String port,
             String loggingCategory) {
         Server server = new Server(host, port);
+        if (isReadOnly()) {
+            return readOnlyError("enabling logging categories");
+        }
         try {
             User user = new User();
             String category = findCategory(loggingCategory);
@@ -451,6 +514,9 @@ public class WildFlyMCPServer {
             @ToolArg(name = "port", required = false) String port,
             String loggingCategory) {
         Server server = new Server(host, port);
+        if (isReadOnly()) {
+            return readOnlyError("removing logging categories");
+        }
         try {
             User user = new User();
             String category = findCategory(loggingCategory);

--- a/wildfly-mcp-server/common/src/main/java/org/wildfly/mcp/WildFlyMCPServer.java
+++ b/wildfly-mcp-server/common/src/main/java/org/wildfly/mcp/WildFlyMCPServer.java
@@ -100,16 +100,6 @@ public class WildFlyMCPServer {
     static final String READ_ONLY_ENV = "WILDFLY_MCP_SERVER_READONLY";
     static final String READ_ONLY_PROPERTY = "org.wildfly.readonly";
 
-    // Operations allowed by invokeWildFlyCLIOperation when read-only mode is
-    // enabled. Any operation whose name starts with "read-" is allowed in
-    // addition to this set.
-    private static final Set<String> READ_ONLY_ALLOWED_OPERATIONS = Set.of(
-            "query",
-            "whoami",
-            "validate-address",
-            "validate-operation",
-            "list-snapshots");
-
     static boolean isReadOnly() {
         String value = System.getenv(READ_ONLY_ENV);
         if (value == null) {
@@ -118,22 +108,31 @@ public class WildFlyMCPServer {
         return Boolean.parseBoolean(value);
     }
 
-    // Returns true if the provided CLI operation is a read-only operation that
-    // is safe to run when read-only mode is enabled. Composite operations are
-    // rejected because their nested steps cannot be validated here.
-    static boolean isReadOnlyOperation(String operation) {
+    // Returns true only if the WildFly management model declares the provided
+    // CLI operation as read-only. The server's own metadata (the "read-only"
+    // flag returned by read-operation-description) is used as the source of
+    // truth rather than matching on the operation name, so an operation that is
+    // semantically read-only but implemented as a write operation is correctly
+    // rejected. Composite operations are not declared read-only and are
+    // therefore rejected as well.
+    boolean isReadOnlyOperation(Server server, User user, CommandContext ctx, String operation) throws Exception {
         if (operation == null) {
             return false;
         }
-        String op = operation.trim();
-        int paren = op.indexOf('(');
-        String head = (paren >= 0 ? op.substring(0, paren) : op).trim();
+        int paren = operation.indexOf('(');
+        String head = (paren >= 0 ? operation.substring(0, paren) : operation).trim();
         int colon = head.lastIndexOf(':');
-        String operationName = (colon >= 0 ? head.substring(colon + 1) : head).trim().toLowerCase();
+        if (colon < 0) {
+            return false;
+        }
+        String address = head.substring(0, colon).trim();
+        String operationName = head.substring(colon + 1).trim();
         if (operationName.isEmpty()) {
             return false;
         }
-        return operationName.startsWith("read-") || READ_ONLY_ALLOWED_OPERATIONS.contains(operationName);
+        ModelNode descRequest = ctx.buildRequest(address + ":read-operation-description(name=" + operationName + ")");
+        ModelNode result = wildflyClient.call(server, user, descRequest).get("result");
+        return result.hasDefined("read-only") && result.get("read-only").asBoolean(false);
     }
 
     private ToolResponse readOnlyError(String action) {
@@ -257,12 +256,12 @@ public class WildFlyMCPServer {
             @ToolArg(name = "port", required = false) String port,
             String operation) {
         Server server = new Server(host, port);
-        if (isReadOnly() && !isReadOnlyOperation(operation)) {
-            return readOnlyError("invoking the non read-only operation '" + operation + "'");
-        }
         try {
             User user = new User();
             CommandContext ctx = CommandContextFactory.getInstance().newCommandContext();
+            if (isReadOnly() && !isReadOnlyOperation(server, user, ctx, operation)) {
+                return readOnlyError("invoking the non read-only operation '" + operation + "'");
+            }
             ModelNode mn = ctx.buildRequest(operation);
             String value = wildflyClient.call(server, user, mn).toJSONString(false);
             return buildResponse(value);

--- a/wildfly-mcp-server/common/src/test/java/org/wildfly/mcp/WildFlyMCPServerTest.java
+++ b/wildfly-mcp-server/common/src/test/java/org/wildfly/mcp/WildFlyMCPServerTest.java
@@ -576,27 +576,10 @@ public class WildFlyMCPServerTest {
     }
 
     @Test
-    public void testIsReadOnlyOperation() {
-        // Read operations are allowed.
-        assertTrue(WildFlyMCPServer.isReadOnlyOperation(":whoami"));
-        assertTrue(WildFlyMCPServer.isReadOnlyOperation(":read-resource(recursive=true)"));
-        assertTrue(WildFlyMCPServer.isReadOnlyOperation("/subsystem=undertow:read-attribute(name=default-server)"));
-        assertTrue(WildFlyMCPServer.isReadOnlyOperation("/deployment=foo.war:read-children-names(child-type=subsystem)"));
-        assertTrue(WildFlyMCPServer.isReadOnlyOperation(":query(select=[name])"));
-
-        // Write/destructive operations are rejected.
-        assertFalse(WildFlyMCPServer.isReadOnlyOperation(":shutdown"));
-        assertFalse(WildFlyMCPServer.isReadOnlyOperation(":reload"));
-        assertFalse(WildFlyMCPServer.isReadOnlyOperation("/subsystem=undertow:write-attribute(name=foo,value=bar)"));
-        assertFalse(WildFlyMCPServer.isReadOnlyOperation("/system-property=foo:add(value=bar)"));
-        assertFalse(WildFlyMCPServer.isReadOnlyOperation(":composite(steps=[])"));
-        assertFalse(WildFlyMCPServer.isReadOnlyOperation(null));
-    }
-
-    @Test
     public void testReadOnlyModeAllowsReadCLIOperation() throws Exception {
+        // The management model declares the operation as read-only.
         ModelNode response = new ModelNode();
-        response.get("result").set("success");
+        response.get("result").get("read-only").set(true);
         when(controllerClientMock.call(any(Server.class), any(User.class), any(ModelNode.class)))
                 .thenReturn(response);
 
@@ -611,9 +594,33 @@ public class WildFlyMCPServerTest {
 
     @Test
     public void testReadOnlyModeBlocksWriteCLIOperation() throws Exception {
+        // The management model declares the operation as NOT read-only.
+        ModelNode response = new ModelNode();
+        response.get("result").get("read-only").set(false);
+        when(controllerClientMock.call(any(Server.class), any(User.class), any(ModelNode.class)))
+                .thenReturn(response);
+
         System.setProperty(WildFlyMCPServer.READ_ONLY_PROPERTY, "true");
         try {
             ToolResponse toolResponse = server.invokeWildFlyCLIOperation("localhost", "9990", ":shutdown");
+            assertTrue(toolResponse.isError());
+        } finally {
+            System.clearProperty(WildFlyMCPServer.READ_ONLY_PROPERTY);
+        }
+    }
+
+    @Test
+    public void testReadOnlyModeRejectsWriteOperationWithReadOnlyLookingName() throws Exception {
+        // The operation name looks read-only, but the management model declares
+        // it as a write operation. The server metadata is the source of truth.
+        ModelNode response = new ModelNode();
+        response.get("result").get("read-only").set(false);
+        when(controllerClientMock.call(any(Server.class), any(User.class), any(ModelNode.class)))
+                .thenReturn(response);
+
+        System.setProperty(WildFlyMCPServer.READ_ONLY_PROPERTY, "true");
+        try {
+            ToolResponse toolResponse = server.invokeWildFlyCLIOperation("localhost", "9990", "/subsystem=foo:read-something");
             assertTrue(toolResponse.isError());
         } finally {
             System.clearProperty(WildFlyMCPServer.READ_ONLY_PROPERTY);

--- a/wildfly-mcp-server/common/src/test/java/org/wildfly/mcp/WildFlyMCPServerTest.java
+++ b/wildfly-mcp-server/common/src/test/java/org/wildfly/mcp/WildFlyMCPServerTest.java
@@ -574,4 +574,104 @@ public class WildFlyMCPServerTest {
         String textResponse = ((TextContent)toolResponse.content().get(0)).text();
         assertEquals("Successfull shutdown of the server", textResponse);
     }
+
+    @Test
+    public void testIsReadOnlyOperation() {
+        // Read operations are allowed.
+        assertTrue(WildFlyMCPServer.isReadOnlyOperation(":whoami"));
+        assertTrue(WildFlyMCPServer.isReadOnlyOperation(":read-resource(recursive=true)"));
+        assertTrue(WildFlyMCPServer.isReadOnlyOperation("/subsystem=undertow:read-attribute(name=default-server)"));
+        assertTrue(WildFlyMCPServer.isReadOnlyOperation("/deployment=foo.war:read-children-names(child-type=subsystem)"));
+        assertTrue(WildFlyMCPServer.isReadOnlyOperation(":query(select=[name])"));
+
+        // Write/destructive operations are rejected.
+        assertFalse(WildFlyMCPServer.isReadOnlyOperation(":shutdown"));
+        assertFalse(WildFlyMCPServer.isReadOnlyOperation(":reload"));
+        assertFalse(WildFlyMCPServer.isReadOnlyOperation("/subsystem=undertow:write-attribute(name=foo,value=bar)"));
+        assertFalse(WildFlyMCPServer.isReadOnlyOperation("/system-property=foo:add(value=bar)"));
+        assertFalse(WildFlyMCPServer.isReadOnlyOperation(":composite(steps=[])"));
+        assertFalse(WildFlyMCPServer.isReadOnlyOperation(null));
+    }
+
+    @Test
+    public void testReadOnlyModeAllowsReadCLIOperation() throws Exception {
+        ModelNode response = new ModelNode();
+        response.get("result").set("success");
+        when(controllerClientMock.call(any(Server.class), any(User.class), any(ModelNode.class)))
+                .thenReturn(response);
+
+        System.setProperty(WildFlyMCPServer.READ_ONLY_PROPERTY, "true");
+        try {
+            ToolResponse toolResponse = server.invokeWildFlyCLIOperation("localhost", "9990", ":whoami");
+            assertFalse(toolResponse.isError());
+        } finally {
+            System.clearProperty(WildFlyMCPServer.READ_ONLY_PROPERTY);
+        }
+    }
+
+    @Test
+    public void testReadOnlyModeBlocksWriteCLIOperation() throws Exception {
+        System.setProperty(WildFlyMCPServer.READ_ONLY_PROPERTY, "true");
+        try {
+            ToolResponse toolResponse = server.invokeWildFlyCLIOperation("localhost", "9990", ":shutdown");
+            assertTrue(toolResponse.isError());
+        } finally {
+            System.clearProperty(WildFlyMCPServer.READ_ONLY_PROPERTY);
+        }
+    }
+
+    @Test
+    public void testReadOnlyModeBlocksShutdown() throws Exception {
+        System.setProperty(WildFlyMCPServer.READ_ONLY_PROPERTY, "true");
+        try {
+            ToolResponse toolResponse = server.shutdownServer(null, null, null);
+            assertTrue(toolResponse.isError());
+        } finally {
+            System.clearProperty(WildFlyMCPServer.READ_ONLY_PROPERTY);
+        }
+    }
+
+    @Test
+    public void testReadOnlyModeBlocksDeploy() throws Exception {
+        System.setProperty(WildFlyMCPServer.READ_ONLY_PROPERTY, "true");
+        try {
+            ToolResponse toolResponse = server.deployWildFlyApplication("localhost", "9990", "/tmp/test.war", null, null);
+            assertTrue(toolResponse.isError());
+        } finally {
+            System.clearProperty(WildFlyMCPServer.READ_ONLY_PROPERTY);
+        }
+    }
+
+    @Test
+    public void testReadOnlyModeBlocksUndeploy() throws Exception {
+        System.setProperty(WildFlyMCPServer.READ_ONLY_PROPERTY, "true");
+        try {
+            ToolResponse toolResponse = server.undeployWildFlyApplication("localhost", "9990", "test.war");
+            assertTrue(toolResponse.isError());
+        } finally {
+            System.clearProperty(WildFlyMCPServer.READ_ONLY_PROPERTY);
+        }
+    }
+
+    @Test
+    public void testReadOnlyModeBlocksEnableLogging() throws Exception {
+        System.setProperty(WildFlyMCPServer.READ_ONLY_PROPERTY, "true");
+        try {
+            ToolResponse toolResponse = server.enableWildFlyLoggingCategory("localhost", "9990", "security");
+            assertTrue(toolResponse.isError());
+        } finally {
+            System.clearProperty(WildFlyMCPServer.READ_ONLY_PROPERTY);
+        }
+    }
+
+    @Test
+    public void testReadOnlyModeBlocksRemoveLogging() throws Exception {
+        System.setProperty(WildFlyMCPServer.READ_ONLY_PROPERTY, "true");
+        try {
+            ToolResponse toolResponse = server.removeWildFlyLoggingCategory("localhost", "9990", "security");
+            assertTrue(toolResponse.isError());
+        } finally {
+            System.clearProperty(WildFlyMCPServer.READ_ONLY_PROPERTY);
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Adds an opt-in **read-only mode** to the WildFly MCP server, enabled via the `WILDFLY_MCP_SERVER_READONLY` environment variable or the `org.wildfly.readonly` system property (same configuration convention as the existing user/host/port settings).

When enabled, the server refuses any operation that would modify the connected WildFly server, **independently of the WildFly user's RBAC role**. This is defense-in-depth on top of the existing `Monitor`-role approach documented in the README: safety no longer depends on configuring RBAC on every target server, and it prevents an LLM from accidentally modifying or stopping a server.

Closes #62.

## Behavior when read-only mode is enabled

- These tools fail fast with an explicit message: `deployWildFlyApplication`, `undeployWildFlyApplication`, `shutdownServer`, `enableWildFlyLoggingCategory`, `removeWildFlyLoggingCategory`.
- `invokeWildFlyCLIOperation` only allows read operations: operation names starting with `read-`, plus `query`, `whoami`, `validate-address`, `validate-operation` and `list-snapshots`. Everything else, including `composite` (whose nested steps can't be validated here), is rejected. This implements the existing `// TODO, implement possible rules if needed to disallow some operations.` in that tool.
- All other read-only tools remain fully available.
- Default behavior is unchanged (mode off) for backward compatibility.

## Changes

- `WildFlyMCPServer.java`: `isReadOnly()` / `isReadOnlyOperation()` helpers, guards on the mutating tools, and the CLI allow-list.
- `WildFlyMCPServerTest.java`: unit tests for the operation classifier and for each guarded tool.
- `wildfly-mcp-server/README.md`: documents the new mode.

## Test plan

- [x] `mvn -pl common test` → `Tests run: 32, Failures: 0, Errors: 0, Skipped: 0` / `BUILD SUCCESS`.
- [x] New tests cover allowed read CLI ops, blocked write CLI ops, and all five guarded tools.
